### PR TITLE
Fix css larghezza targa e colore placeholder

### DIFF
--- a/plate.html
+++ b/plate.html
@@ -1,3 +1,11 @@
-<div class="container">
-   <input type="text" name="licenseplate" class="licenseplate" maxlength="9" placeholder="AB 123 AB"/>
-</div>
+<!DOCTYPE html>
+<html>
+	<head>
+		<link href="style.css" rel="stylesheet" type="text/css">
+	</head>
+	<body>
+		<div class="container">
+			<input type="text" name="licenseplate" class="licenseplate" maxlength="9" placeholder="AB 123 AB"/>
+		</div>
+	</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ body {
 }
 
 .container {
-  width: 510px;
+  width: 590px;
   margin: 20px auto;
 }
 
@@ -23,12 +23,13 @@ body {
   padding-left: 60px;
   padding-bottom: 10px;
   
-  width: 510px;
+  width: 590px;
   border: 5px solid red;
   border-radius: 15px;
   outline: none;
-  
-  &::placeholder {
-    color: #eee;
-  }
+
+}
+
+.licenseplate::placeholder {
+  color: #eee;
 }


### PR DESCRIPTION
La larghezza impostata precedentemente lasciava fuori un carattere. In più il css del placeholder non era valido